### PR TITLE
(4-2) 従業員詳細画面の価格フォーマットの修正

### DIFF
--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -168,7 +168,7 @@
                   <tr>
                     <th nowrap>給料</th>
                     <td>
-                      <span th:utext="${employee.salary + '円'}">400000円</span>
+                      <span th:utext="${#numbers.formatInteger(employee.salary,3,'COMMA') + '円'}">400000円</span>
                     </td>
                   </tr>
                   <tr>


### PR DESCRIPTION
- 価格表示を３桁のカンマ区切りで表示するように修正. 
例 200000円 → 200,000円